### PR TITLE
Fixed a compile error in the StringExtensions class declaration.

### DIFF
--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -290,7 +290,7 @@ internal sealed class ChainablePath
 #if PATHY_PUBLIC
 public static class StringExtensions
 #else
-internal static sealed class StringExtensions
+internal static class StringExtensions
 #endif
 {
     /// <summary>


### PR DESCRIPTION
This pull request includes a minor change to the `Pathy/ChainablePath.cs` file. The change modifies the `StringExtensions` class to remove the `sealed` modifier, making it a non-sealed internal static class.