### PR TITLE
Nullable properties returning ChainablePath now return ChainablePath.Empty

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -3,7 +3,7 @@ namespace Pathy
 {
     public readonly struct ChainablePath : System.IEquatable<Pathy.ChainablePath>
     {
-        public Pathy.ChainablePath? Directory { get; }
+        public Pathy.ChainablePath Directory { get; }
         public bool DirectoryExists { get; }
         public string DirectoryName { get; }
         public bool Exists { get; }
@@ -16,6 +16,7 @@ namespace Pathy
         public Pathy.ChainablePath Parent { get; }
         public Pathy.ChainablePath Root { get; }
         public static Pathy.ChainablePath Current { get; }
+        public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -3,7 +3,7 @@ namespace Pathy
 {
     public readonly struct ChainablePath : System.IEquatable<Pathy.ChainablePath>
     {
-        public Pathy.ChainablePath? Directory { get; }
+        public Pathy.ChainablePath Directory { get; }
         public bool DirectoryExists { get; }
         public string DirectoryName { get; }
         public bool Exists { get; }
@@ -16,6 +16,7 @@ namespace Pathy
         public Pathy.ChainablePath Parent { get; }
         public Pathy.ChainablePath Root { get; }
         public static Pathy.ChainablePath Current { get; }
+        public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -3,7 +3,7 @@ namespace Pathy
 {
     public readonly struct ChainablePath : System.IEquatable<Pathy.ChainablePath>
     {
-        public Pathy.ChainablePath? Directory { get; }
+        public Pathy.ChainablePath Directory { get; }
         public bool DirectoryExists { get; }
         public string DirectoryName { get; }
         public bool Exists { get; }
@@ -16,6 +16,7 @@ namespace Pathy
         public Pathy.ChainablePath Parent { get; }
         public Pathy.ChainablePath Root { get; }
         public static Pathy.ChainablePath Current { get; }
+        public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -3,7 +3,7 @@ namespace Pathy
 {
     public readonly struct ChainablePath : System.IEquatable<Pathy.ChainablePath>
     {
-        public Pathy.ChainablePath? Directory { get; }
+        public Pathy.ChainablePath Directory { get; }
         public bool DirectoryExists { get; }
         public string DirectoryName { get; }
         public bool Exists { get; }
@@ -16,6 +16,7 @@ namespace Pathy
         public Pathy.ChainablePath Parent { get; }
         public Pathy.ChainablePath Root { get; }
         public static Pathy.ChainablePath Current { get; }
+        public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -13,7 +13,7 @@ public class ChainablePathSpecs
 
     public ChainablePathSpecs()
     {
-        testFolder =  ChainablePath.Temp / nameof(ChainablePathSpecs);
+        testFolder =  ChainablePath.Temp / nameof(ChainablePathSpecs) / Environment.Version.ToString();
         testFolder.DeleteFileOrDirectory();
         testFolder.CreateDirectoryRecursively();
     }
@@ -310,7 +310,8 @@ public class ChainablePathSpecs
         var path = ChainablePath.From("C://");
 
         // Assert
-        path.Directory.Should().BeNull();
+        path.Directory.Should().Be(ChainablePath.Empty);
+        path.Directory.ToString().Should().BeEmpty();
     }
 
     [Fact]

--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -17,12 +17,17 @@ public readonly record struct ChainablePath
 internal readonly record struct ChainablePath
 #endif
 {
-    private readonly string path;
+    private readonly string path = string.Empty;
 
     private ChainablePath(string path)
     {
         this.path = path;
     }
+
+    /// <summary>
+    /// Represents an empty <see cref="ChainablePath"/> instance.
+    /// </summary>
+    public static ChainablePath Empty { get; } = new(string.Empty);
 
     /// <summary>
     /// Gets a default, empty <see cref="ChainablePath"/> instance.
@@ -158,39 +163,39 @@ internal readonly record struct ChainablePath
     /// <summary>
     /// If the current path represents a file, gets the directory of that file.
     /// Or, if the current path represents a directory, gets the parent directory.
-    /// Returns <c>null</c> if the path represents the root of a file system.
+    /// Returns <see cref="Empty"/> if the path represents the root of a file system.
     /// </summary>
-    public ChainablePath? Directory
+    public ChainablePath Directory
     {
         get
         {
             string directory = DirectoryName;
-            if (directory is not null)
+            if (directory.Length > 0)
             {
                 return From(directory);
             }
 
-            return null;
+            return Empty;
         }
     }
 
     /// <summary>
     /// If the current path represents a file, gets the directory of that file.
     /// Or, if the current path represents a directory, gets the parent directory.
-    /// Returns <c>null</c> if the path represents the root of a file system.
+    /// Returns <see cref="Empty"/> if the path represents the root of a file system.
     /// </summary>
     public ChainablePath Parent => From(DirectoryName);
 
     /// <summary>
     /// If the current path represents a file, gets the directory of that file.
     /// Or, if the current path represents a directory, gets the parent directory.
-    /// Returns <c>null</c> if the path represents the root of a file system.
+    /// Returns an empty string if the path represents the root of a file system.
     /// </summary>
     public string DirectoryName
     {
         get
         {
-            return Path.GetDirectoryName(path.TrimEnd(Path.DirectorySeparatorChar));
+            return Path.GetDirectoryName(path.TrimEnd(Path.DirectorySeparatorChar)) ?? "";
         }
     }
 


### PR DESCRIPTION
This pull request introduces several updates to the `ChainablePath` struct and its associated tests and documentation. The changes improve the handling of empty paths, standardize behavior for root directories, and enhance test coverage. The most significant updates include replacing nullable `ChainablePath?` with a non-nullable `ChainablePath` using a new `Empty` static property, modifying related methods and tests, and updating API verification files to reflect these changes.

Solves #25 