### PR TITLE
Added FindFirst to find the first file or directory matching a specification

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -25,6 +25,8 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
+        public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -26,6 +26,8 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
+        public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -25,6 +25,8 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
+        public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -26,6 +26,8 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
+        public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }

--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
+
+// ReSharper disable UseIndexFromEndExpression
 
 #pragma warning disable
 
@@ -73,6 +76,69 @@ internal readonly record struct ChainablePath
         {
             throw new ArgumentException($"Path {path} is not valid", nameof(path));
         }
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ChainablePath"/> representing the first existing path from the specified list of paths.
+    /// </summary>
+    /// <param name="paths">
+    /// An array of string representations of paths to check for existence. Paths are checked in the order provided.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ChainablePath"/> object representing the first path that exists or <see cref="Empty"/> if none exist.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if the <paramref name="paths"/> array is null.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the <paramref name="paths"/> array is empty.
+    /// </exception>
+    public static ChainablePath FindFirst(params string[] paths)
+    {
+        if (paths == null)
+        {
+            throw new ArgumentNullException(nameof(paths));
+        }
+
+        return FindFirst(paths.Select(From).ToArray());
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ChainablePath"/> representing the first existing path from the specified list of paths.
+    /// </summary>
+    /// <param name="paths">
+    /// An array of <see cref="ChainablePath"/> instances to check for existence. Paths are checked in the order provided.
+    /// </param>
+    /// <returns>
+    /// A <see cref="ChainablePath"/> object representing the first path that exists or <see cref="Empty"/> if none exist.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if the <paramref name="paths"/> array is null.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the <paramref name="paths"/> array is empty.
+    /// </exception>
+    public static ChainablePath FindFirst(params ChainablePath[] paths)
+    {
+        if (paths == null)
+        {
+            throw new ArgumentNullException(nameof(paths));
+        }
+
+        if (paths.Length == 0)
+        {
+            throw new ArgumentException("At least one path must be provided", nameof(paths));
+        }
+
+        foreach (var path in paths)
+        {
+            if (path.Exists)
+            {
+                return path;
+            }
+        }
+
+        return Empty;
     }
 
     private static string NormalizeSlashes(string path)

--- a/README.md
+++ b/README.md
@@ -41,17 +41,30 @@
 
 Pathy is a tiny source-only library that will allow you to build file and directory paths by chaining together strings like `"c:"`, `"dir1"`, `"dir2"` using
 
-  `ChainablePath.New() / "c:" / "dir1" / "dir2"`.
+```csharp
+ChainablePath.New() / "c:" / "dir1" / "dir2";
+```
+
+Note how the `/` operator is used to chain multiple parts of a path together. This is the primary feature of Pathy. And it doesn't matter if you do that on Linux or Windows. Internally it'll use whatever path separator is suitable.
+
+You can also use the `+` operator to add some phrase to the path _without_ using a separator.
+
+```csharp
+var path = ChainablePath.From("c:") / "my-path" / "to" / "a" / "directory";
+
+path = path + "2"
+
+// Returns "c:/my-path/to/a/directory2"
+string result = path.ToString();
+```
 
 It was heavily inspired by the best build pipeline framework available in the .NET space, [Nuke](https://nuke.build/). Nuke has supported these concepts for many years, but I needed this capability outside build pipelines. Lots of kudos to [Matthias Koch](https://www.linkedin.com/in/matthias-koch-jb/) for what I see as a brilliant idea.
-
-It doesn't have any dependencies and runs on .NET 4.7, .NET 8, as well as frameworks supporting .NET Standard 2.0 and 2.1.
 
 ### What's so special about that?
 
 It makes those chained calls to `Path.Combine` a thing from the past and hides the ugliness of dealing with (trailing) slashes.
 
-It ships as a source-only package, which means you can use it in your own libraries and projects, without incurring any dependency pain on your consuming projects.
+It ships as a source-only package, which means you can use it in your own libraries and projects, without incurring any dependency pain on your consuming projects. It runs on .NET 4.7, .NET 8, as well as frameworks supporting .NET Standard 2.0 and 2.1.
 
 The core Pathy package does not have any dependencies, and I purposely moved the [globbing](https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing#pattern-formats) functionality into a separate package as it depends on `Microsoft.Extensions.FileSystemGlobbing`.
 
@@ -74,26 +87,18 @@ It all starts with the construction of a `ChainablePath` instance to represent a
 There are several ways of doing that.
 
 ```csharp
+// Various ways for constructing a ChainablePath 
 var path = ChainablePath.From("c:") / "my-path" / "to" / "a" /"directory");
 var path = ChainablePath.New() / "c:" / "my-path" / "to" / "a" / "directory";
 var path = "c:/mypath/to/a/directory".ToPath();
 var path = (ChainablePath)"c:/mypath/to/a/directory";
+
+// Find the first available file in the order of appearance and return a
+// ChainablePath representing that file
+var path = ChainablePath.FindFirst("build.yml", ".github\\build.yml");
 ```
 
 Additionally, you can use `ChainablePath.Current` to get the current working directory as an instance of `ChainablePath`, and `ChainablePath.Temp` to get that for the user's temporary folder.
-
-The first thing you'll notice is how the `/` operator is used to chain multiple parts of a path together. This is the primary feature of Pathy. And it doesn't matter if you do that on Linux or Windows. Internally it'll use whatever path separator is suitable.
-
-You can also use the `+` operator to add some phrase to the path _without_ using a separator.
-
-```csharp
-var path = ChainablePath.From("c:") / "my-path" / "to" / "a" / "directory";
-
-path = path + "2"
-
-// Returns "c:/my-path/to/a/directory2"
-string result = path.ToString();
-```
 
 To convert an instance of `ChainablePath` back to a `string`, you can either call `ToString()` or cast the instance to a `string`.
 


### PR DESCRIPTION
This pull request introduces a new utility to the `ChainablePath` API for finding the first existing path from a list of candidates, along with comprehensive unit tests and minor code cleanups. The most significant changes are the addition of the `FindFirst` methods (supporting both string and `ChainablePath` inputs), updates to the public API, and new tests to ensure correct behavior.

### New API functionality

* Added two overloads of `ChainablePath.FindFirst`: one accepting an array of strings and one accepting an array of `ChainablePath` objects. These methods return the first path that exists, or `ChainablePath.Empty` if none exist, and throw exceptions for null or empty arguments.
* Updated the public API files for all supported target frameworks to include the new methods `FromFirstExisting(params Pathy.ChainablePath[] paths)` and `FromFirstExisting(params string[] paths)`. [[1]](diffhunk://#diff-15d99b07e9450d91b8ad1a09b724fcf0dd8350fb5216a1b33c8b69112792726aR29-R30) [[2]](diffhunk://#diff-123ba68a672c0227fc4ea25c7cfb8cbfd88e40a915a087ffb42332b4d623add3R30-R31)

### Test coverage

* Added a comprehensive set of tests in `ChainablePathSpecs.cs` to verify the new `FindFirst` functionality, covering cases for files and directories, string and `ChainablePath` overloads, non-existing paths, null/empty input handling, and usage examples.

### Code and test cleanup

* Standardized the use of the directory separator character by renaming the `slash` field to `Slash` and updating all usages to the new static field for improved code clarity and consistency. [[1]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07R3-R12) [[2]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L60-R60) [[3]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L96-R104) [[4]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L167-R167) [[5]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L181-R181) [[6]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L191-R191) [[7]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L204-R204) [[8]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L238-R238) [[9]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L249-R249) [[10]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07L344-L347)

### Minor improvements

* Added `using System.Linq;` where needed to support the new functionality. [[1]](diffhunk://#diff-387d55bf64634e4bb5204771367febaac4c6eded099740c1f9b0c6a37684d55eR5-R7) [[2]](diffhunk://#diff-c6c5216c59d3d1647c8e3aeebd6a7b8039862881737c14baf9a1c81c39ea8e07R3-R12)

These changes make it easier to work with multiple potential file or directory paths by providing a simple, robust way to select the first one that exists.…ication.