### PR TITLE
Add FindParentWithFileMatching to find the closest parent directory containing a file matching wildcards

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -19,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
+        public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }
         public Pathy.ChainablePath ToAbsolute() { }
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -20,6 +20,7 @@ namespace Pathy
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }
+        public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }
         public Pathy.ChainablePath ToAbsolute() { }
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -19,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
+        public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }
         public Pathy.ChainablePath ToAbsolute() { }
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -20,6 +20,7 @@ namespace Pathy
         public static Pathy.ChainablePath New { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }
+        public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }
         public Pathy.ChainablePath ToAbsolute() { }
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }

--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ Given an instance of `ChainablePath`, you can get a lot of useful information:
 * Want to know the delta between two paths? Use `AsRelativeTo`.
 * To determine if a file has a case-insensitive extension, use `HasExtension(".txt")` or `HasExtension("txt")`.
 
+And if the built-in functionality really isn't enough, you can always call `ToDirectoryInfo` or `ToFileInfo` to continue with an instance of `DirectoryInfo` and `FileInfo`.
+
 Other features
 * Build an absolute path from a relative path using `ToAbsolute` to use the current directory as the base or `ToAbsolute(parentPath)` to use something else as the base.
-
-And if the built-in functionality really isn't enough, you can always call `ToDirectoryInfo` or `ToFileInfo` to continue with an instance of `DirectoryInfo` and `FileInfo`.
+* Finding the closest parent directory containing a file matching one or more wildcards. For example, given you have a `ChainablePath` pointing to a `.csproj` file, you can then use `FindParentWithFileMatching("*.sln", "*.slnx")` to find the directory containing the `.sln` or `.slnx` file.
 
 ### Globbing
 


### PR DESCRIPTION
Introduces a new method, `FindParentWithFileMatching`, to the `ChainablePath` class. This method enables users to locate the nearest parent directory that contains a file matching one or more provided wildcard patterns (e.g., "*.sln"). It validates the input parameters to ensure that the provided wildcard patterns are non-null and non-empty. If no parent directory contains a matching file, the method returns `ChainablePath.Empty`. This method enhances the usability of `ChainablePath` by adding a feature for directory hierarchy traversal based on file patterns.

Closes #44 