### PR TITLE
Added `Null` and `IsNull` to eventually replace `Empty`

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -11,6 +11,7 @@ namespace Pathy
         public bool FileExists { get; }
         public bool IsDirectory { get; }
         public bool IsFile { get; }
+        public bool IsNull { get; }
         public bool IsRooted { get; }
         public string Name { get; }
         public Pathy.ChainablePath Parent { get; }
@@ -18,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Current { get; }
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
+        public static Pathy.ChainablePath Null { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -11,6 +11,7 @@ namespace Pathy
         public bool FileExists { get; }
         public bool IsDirectory { get; }
         public bool IsFile { get; }
+        public bool IsNull { get; }
         public bool IsRooted { get; }
         public string Name { get; }
         public Pathy.ChainablePath Parent { get; }
@@ -18,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Current { get; }
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
+        public static Pathy.ChainablePath Null { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }
         public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -11,6 +11,7 @@ namespace Pathy
         public bool FileExists { get; }
         public bool IsDirectory { get; }
         public bool IsFile { get; }
+        public bool IsNull { get; }
         public bool IsRooted { get; }
         public string Name { get; }
         public Pathy.ChainablePath Parent { get; }
@@ -18,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Current { get; }
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
+        public static Pathy.ChainablePath Null { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }
         public bool HasExtension(string extension) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -11,6 +11,7 @@ namespace Pathy
         public bool FileExists { get; }
         public bool IsDirectory { get; }
         public bool IsFile { get; }
+        public bool IsNull { get; }
         public bool IsRooted { get; }
         public string Name { get; }
         public Pathy.ChainablePath Parent { get; }
@@ -18,6 +19,7 @@ namespace Pathy
         public static Pathy.ChainablePath Current { get; }
         public static Pathy.ChainablePath Empty { get; }
         public static Pathy.ChainablePath New { get; }
+        public static Pathy.ChainablePath Null { get; }
         public static Pathy.ChainablePath Temp { get; }
         public Pathy.ChainablePath AsRelativeTo(Pathy.ChainablePath basePath) { }
         public Pathy.ChainablePath FindParentWithFileMatching(params string[] wildcards) { }

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -568,7 +568,7 @@ public class ChainablePathSpecs
         var result = childDir.FindParentWithFileMatching("*.sln");
 
         // Assert
-        result.Should().Be(ChainablePath.Empty);
+        result.Should().Be(ChainablePath.Null);
     }
 
     [Fact]
@@ -765,7 +765,7 @@ public class ChainablePathSpecs
         var result = ChainablePath.FindFirst(nonExistingFile1.ToString(), nonExistingFile2.ToString());
 
         // Assert
-        result.Should().Be(ChainablePath.Empty);
+        result.IsNull.Should().BeTrue();
     }
 
     [Fact]

--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -33,6 +33,14 @@ internal readonly record struct ChainablePath
     public static ChainablePath Empty { get; } = new(string.Empty);
 
     /// <summary>
+    /// Represents a <see cref="ChainablePath"/> not pointing to any file or directory.
+    /// </summary>
+    /// <remarks>
+    /// Implements the Null Pattern and should be used as a replacement of <see cref="Empty"/>
+    /// </remarks>
+    public static ChainablePath Null { get; } = new(string.Empty);
+
+    /// <summary>
     /// Gets a default, empty <see cref="ChainablePath"/> instance.
     /// </summary>
     public static ChainablePath New => new(string.Empty);
@@ -220,6 +228,11 @@ internal readonly record struct ChainablePath
     {
         return From(leftPath.ToString() + additionalPath);
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the current <see cref="ChainablePath"/> instance is equal to <see cref="ChainablePath.Null"/>.
+    /// </summary>
+    public bool IsNull => Equals(Null);
 
     /// <summary>
     /// Gets the name of the file or directory represented by the current path, without the parent directory.


### PR DESCRIPTION
This pull request introduces a new "null" path concept to the `ChainablePath` API, replacing the previous use of the "empty" path for scenarios where a path does not exist or a search yields no results. The main changes include adding the `Null` static property, the `IsNull` property, and updating tests and API verification files to use and recognize these new members.
