### PR TITLE
Add ToUri and FromUri to ChainablePath

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -30,9 +30,11 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public System.Uri ToUri() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
+        public static Pathy.ChainablePath FromUri(System.Uri uri) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }
         public static Pathy.ChainablePath operator +(Pathy.ChainablePath leftPath, string additionalPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -31,9 +31,11 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public System.Uri ToUri() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
+        public static Pathy.ChainablePath FromUri(System.Uri uri) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }
         public static Pathy.ChainablePath operator +(Pathy.ChainablePath leftPath, string additionalPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -30,9 +30,11 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public System.Uri ToUri() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
+        public static Pathy.ChainablePath FromUri(System.Uri uri) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }
         public static Pathy.ChainablePath operator +(Pathy.ChainablePath leftPath, string additionalPath) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -31,9 +31,11 @@ namespace Pathy
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
         public override string ToString() { }
+        public System.Uri ToUri() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }
+        public static Pathy.ChainablePath FromUri(System.Uri uri) { }
         public static string op_Implicit(Pathy.ChainablePath chainablePath) { }
         public static Pathy.ChainablePath op_Implicit(string path) { }
         public static Pathy.ChainablePath operator +(Pathy.ChainablePath leftPath, string additionalPath) { }

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -1186,4 +1186,110 @@ public class ChainablePathSpecs
             .WithParameterName("range");
     }
 #endif
+
+    [Fact]
+    public void Can_convert_an_absolute_path_to_a_file_uri()
+    {
+        // Arrange
+        var path = testFolder / "report.txt";
+
+        // Act
+        var uri = path.ToUri();
+
+        // Assert
+        uri.IsAbsoluteUri.Should().BeTrue();
+        uri.Scheme.Should().Be(Uri.UriSchemeFile);
+        uri.LocalPath.Should().Be(path.ToString());
+    }
+
+    [Fact]
+    public void Cannot_convert_a_relative_path_to_a_uri()
+    {
+        // Arrange
+        ChainablePath path = "relative/path.txt";
+
+        // Act
+        var act = () => path.ToUri();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*must be absolute*");
+    }
+
+    [Fact]
+    public void Can_round_trip_an_absolute_path_through_to_uri_and_from_uri()
+    {
+        // Arrange
+        var path = testFolder / "report.txt";
+
+        // Act
+        var result = ChainablePath.FromUri(path.ToUri());
+
+        // Assert
+        result.ToString().Should().Be(path.ToString());
+    }
+
+    [Fact]
+    public void Can_round_trip_a_path_with_spaces_and_special_characters()
+    {
+        // Arrange
+        var path = testFolder / "my report (final) #1.txt";
+
+        // Act
+        var uri = path.ToUri();
+        var result = ChainablePath.FromUri(uri);
+
+        // Assert
+        result.ToString().Should().Be(path.ToString());
+    }
+
+    [Fact]
+    public void Can_convert_a_unc_path_to_a_uri_and_back()
+    {
+        // Arrange
+        ChainablePath path = @"\\server\share\file.txt";
+
+        // Act
+        var uri = path.ToUri();
+        var result = ChainablePath.FromUri(uri);
+
+        // Assert
+        uri.IsUnc.Should().BeTrue();
+        uri.Host.Should().Be("server");
+        result.ToString().Should().Be(path.ToString());
+    }
+
+    [Fact]
+    public void From_uri_rejects_a_null_uri()
+    {
+        // Act
+        var act = () => ChainablePath.FromUri(null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("uri");
+    }
+
+    [Fact]
+    public void From_uri_rejects_a_non_file_scheme()
+    {
+        // Act
+        var act = () => ChainablePath.FromUri(new Uri("https://example.com/some/path"));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*https*")
+            .WithParameterName("uri");
+    }
+
+    [Fact]
+    public void From_uri_rejects_a_relative_uri()
+    {
+        // Act
+        var act = () => ChainablePath.FromUri(new Uri("relative/path.txt", UriKind.Relative));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*absolute*")
+            .WithParameterName("uri");
+    }
 }

--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -90,6 +90,42 @@ namespace Pathy
         }
 
         /// <summary>
+        /// Creates a new instance of <see cref="ChainablePath"/> from a <c>file://</c> <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="uri">
+        /// An absolute <see cref="Uri"/> using the <c>file</c> scheme.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ChainablePath"/> object representing the local path denoted by the <paramref name="uri"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if the <paramref name="uri"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the <paramref name="uri"/> is not absolute or does not use the <c>file</c> scheme.
+        /// </exception>
+        public static ChainablePath FromUri(Uri uri)
+        {
+            if (uri is null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (!uri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("URI must be absolute to convert to a path", nameof(uri));
+            }
+
+            if (uri.Scheme != Uri.UriSchemeFile)
+            {
+                throw new ArgumentException(
+                    $"URI must use the '{Uri.UriSchemeFile}' scheme, but was '{uri.Scheme}'", nameof(uri));
+            }
+
+            return From(uri.LocalPath);
+        }
+
+        /// <summary>
         /// Creates a new instance of <see cref="ChainablePath"/> representing the first existing path from the specified list of paths.
         /// </summary>
         /// <param name="paths">
@@ -466,6 +502,24 @@ namespace Pathy
         public FileInfo ToFileInfo()
         {
             return new FileInfo(ToString());
+        }
+
+        /// <summary>
+        /// Converts the current <see cref="ChainablePath"/> instance to a <c>file://</c> <see cref="Uri"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the current path is not absolute (rooted). Relative paths have no unambiguous URI representation,
+        /// so this method never resolves them against the current directory.
+        /// </exception>
+        public Uri ToUri()
+        {
+            if (!IsRooted)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot convert relative path '{path}' to a URI. The path must be absolute.");
+            }
+
+            return new Uri(path);
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <h1 align="center">
+
+
   <br>
   <img src="./logo.png" style="width:300px" alt="Pathy"/>
   <br>


### PR DESCRIPTION
## Summary

Implements the API proposal in #146:

```csharp
public Uri ToUri();
public static ChainablePath FromUri(Uri uri);
```

## Design decisions

- **`ToUri()` throws on relative paths** instead of silently resolving against the current working directory. Implicitly resolving against `cwd` would be a surprising side effect for a path library — the caller should make that resolution explicit (e.g. via `ToAbsolute()`) before calling `ToUri()`. Throws `InvalidOperationException` with a message stating the path must be absolute.
- **`ToUri()` delegates to `new Uri(string)`** for absolute paths rather than hand-rolling escaping logic. The built-in constructor already produces correct `file://` URIs (with proper percent-escaping) for both regular absolute paths and UNC paths.
- **`FromUri(Uri)` restricts to the `file` scheme** and requires an absolute `Uri`, throwing `ArgumentException` otherwise (mentioning the rejected scheme), and `ArgumentNullException` for a null `Uri`. It builds the `ChainablePath` from `uri.LocalPath`, which already handles UNC paths and percent-decoding correctly.
- No implicit conversion to/from `Uri` was added (per the issue's rejected alternatives), and `FromUri` only accepts a `Uri`, not a `string`, keeping the surface minimal as scoped in the issue.

## Testing

- Added unit tests in `Pathy.Specs/ChainablePathSpecs.cs` covering: absolute path round-trip through `ToUri`/`FromUri`, relative path throwing on `ToUri`, UNC path handling, rejection of non-file schemes, rejection of relative URIs, null-uri check, and paths with spaces/special characters.
- `dotnet test Pathy.Specs` — 117 passed (net8.0).
- `dotnet test Pathy.ApiVerificationTests` — 8 passed across all four target frameworks (net47, net8.0, netstandard2.0, netstandard2.1) after regenerating the approved API snapshots via `AcceptApiChanges.ps1`.

Fixes #146
