### PR TITLE
Run the analyzers against a target framework the projects actually build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,21 +5,23 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900;NU1902;NU1903</WarningsNotAsErrors> <!-- disable EOL warnings -->
     <NoWarn>1591;1573</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- The single target framework the analyzers run against. Keep this in sync with the newest TFM the projects build. -->
+    <AnalyzerTargetFramework>net8.0</AnalyzerTargetFramework>
   </PropertyGroup>
 
   <!-- To reduce build times, we only enable analyzers for the newest TFM -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != '$(AnalyzerTargetFramework)'">
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(AnalyzerTargetFramework)'">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>7.0</AnalysisLevel>
     <AnalysisMode>All</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == '$(AnalyzerTargetFramework)'">
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Pathy.Specs/ChainablePathExtensionSpecs.cs
+++ b/Pathy.Specs/ChainablePathExtensionSpecs.cs
@@ -91,7 +91,7 @@ public class ChainablePathExtensionSpecs
         File.WriteAllText(file, "Hello World!");
 
         // Act
-        var act = () => file.MoveFileOrDirectory(testFolder / "SomeDestination", newName: "");
+        var act = () => file.MoveFileOrDirectory(testFolder / "SomeDestination", "");
 
         // Assert
         act.Should().Throw<ArgumentException>()

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -560,7 +560,7 @@ public class ChainablePathSpecs
         temp.CreateDirectoryRecursively();
 
         // Act & Assert
-        var act = () => temp.GlobFiles(new string[0]);
+        var act = () => temp.GlobFiles(Array.Empty<string>());
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("*At least one glob pattern must be provided*")
@@ -938,7 +938,7 @@ public class ChainablePathSpecs
     {
         // Act & Assert
         var act = () =>
-            ChainablePath.FindFirst(new string[0]);
+            ChainablePath.FindFirst(Array.Empty<string>());
 
         // Assert
         act.Should().Throw<ArgumentException>()
@@ -951,7 +951,7 @@ public class ChainablePathSpecs
     {
         // Act & Assert
         var act = () =>
-            ChainablePath.FindFirst(new ChainablePath[0]);
+            ChainablePath.FindFirst(Array.Empty<ChainablePath>());
 
         act.Should().Throw<ArgumentException>()
             .WithMessage("*At least one path must be provided*")
@@ -1178,7 +1178,7 @@ public class ChainablePathSpecs
         path.CreateDirectoryRecursively();
 
         // Act
-        Action act = () => { var _ = path / 1..3; };
+        Action act = () => { _ = path / 1..3; };
 
         // Assert
         act.Should().Throw<ArgumentException>()


### PR DESCRIPTION
Fixes #155.

## The problem

`Directory.Build.props` gated the whole analyzer setup on a `net6.0` target framework:

```xml
<PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">  <!-- turn analyzers off -->
<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">  <!-- analysis level and mode -->
<ItemGroup     Condition="'$(TargetFramework)' == 'net6.0'">  <!-- the five analyzer packages -->
```

No project in this repository targets `net6.0`. The projects build `netstandard2.0`, `netstandard2.1`, `net47`, `net472` and `net8.0`. So the condition never matched, the analyzer packages were never restored, and no analyzer ever ran. The build was green because nothing was being checked.

That silently disabled BannedApiAnalyzers, StyleCop, CSharpGuidelinesAnalyzer, Roslynator, Meziantou and the built-in .NET analyzers, together with `AnalysisMode=All` and `CodeAnalysisTreatWarningsAsErrors=true`.

## The change

Point the gate at `net8.0`, the newest target framework actually in use, and hold that value in one property instead of repeating it three times:

```xml
<AnalyzerTargetFramework>net8.0</AnalyzerTargetFramework>
```

The three conditions now compare against `$(AnalyzerTargetFramework)`. That is the point of the property: the value cannot drift out of sync again the next time the target frameworks change. The existing comment is kept and reworded so it no longer names a specific framework.

## What turning the analyzers on found

Eight diagnostics across four rule IDs. `CA1825` and `MA0005` flag the same three sites, so it is five distinct locations, all in `Pathy.Specs`.

| Count | Rule | Meaning |
| --- | --- | --- |
| 3 | CA1825 | Avoid zero-length array allocations |
| 3 | MA0005 | Use `Array.Empty<T>()` |
| 1 | AV1555 | Named argument in a call |
| 1 | SA1312 | Variable `_` should begin with a lower-case letter |

All five are fixed here rather than suppressed:

- `new string[0]` and `new ChainablePath[0]` become `Array.Empty<string>()` and `Array.Empty<ChainablePath>()`. These tests only need an empty array to assert argument validation, so behaviour is unchanged.
- `var _ = path / 1..3;` becomes a real discard, `_ = path / 1..3;`, which removes the variable instead of renaming it.
- The `newName:` argument name is dropped. The test still asserts on the message that mentions `newName`.

No `.editorconfig` severity was changed, no rule was downgraded, and no `#pragma` was added. The backlog was small enough to fix properly, which is the better outcome than silencing it.

None of the diagnostics pointed at a real defect. They are all style or micro-allocation issues in test code, so there is no hidden bug being fixed here.

## Scope: what this does not cover

All three shipped source files (`Pathy/ChainablePath.cs`, `Pathy/ChainablePathExtensions.cs`, `Pathy.Globbing/PathyGlobbing.cs`) start with a bare, file-wide `#pragma warning disable`. The product code therefore stays analyzer-silent regardless of this change. That looks deliberate for a source-only package, because consumers compile these files into their own assembly and must not inherit warnings from vendored source.

So in practice this change enables the analyzers for the test and API verification projects. Analysing the product code would mean revisiting that pragma, which is a separate and much larger decision. This PR does not touch it.

## Verification

- Full solution build in Release with the analyzers escalated to errors, exactly as configured: 0 warnings, 0 errors.
- Tests: `Pathy.Specs` net8.0 109 passed, `Pathy.ApiVerificationTests` net8.0 8 passed, 0 failures. The `net472` run reports "No test is available ... make sure that test discoverer & executors are registered". That reproduces on unmodified `main`, so it is a pre-existing local environment issue and not a regression.
- To confirm the gate is genuinely live rather than green by accident, I added a throwaway attribute type to `Pathy.Specs` and it failed the build with `CA1018`, `MA0010` and `RCS1203` as errors. The probe file was removed again.
- The diagnostic count was collected with warnings-as-errors turned off, so the compiler's 100-error limit could not truncate the list.

This is independent of #153 and branches from `main`, so the two can be reviewed and merged in either order.