### PR TITLE
Add Matches(pattern) for pattern matching without touching the file system

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.net47.verified.txt
@@ -5,5 +5,7 @@ namespace Pathy
     {
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, string globPattern) { }
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, params string[] globPatterns) { }
+        public static bool Matches(this Pathy.ChainablePath path, string globPattern) { }
+        public static bool Matches(this Pathy.ChainablePath path, params string[] globPatterns) { }
     }
 }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.net8.0.verified.txt
@@ -5,5 +5,7 @@ namespace Pathy
     {
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, string globPattern) { }
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, params string[] globPatterns) { }
+        public static bool Matches(this Pathy.ChainablePath path, string globPattern) { }
+        public static bool Matches(this Pathy.ChainablePath path, params string[] globPatterns) { }
     }
 }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.netstandard2.0.verified.txt
@@ -5,5 +5,7 @@ namespace Pathy
     {
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, string globPattern) { }
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, params string[] globPatterns) { }
+        public static bool Matches(this Pathy.ChainablePath path, string globPattern) { }
+        public static bool Matches(this Pathy.ChainablePath path, params string[] globPatterns) { }
     }
 }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.netstandard2.1.verified.txt
@@ -5,5 +5,7 @@ namespace Pathy
     {
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, string globPattern) { }
         public static Pathy.ChainablePath[] GlobFiles(this Pathy.ChainablePath path, params string[] globPatterns) { }
+        public static bool Matches(this Pathy.ChainablePath path, string globPattern) { }
+        public static bool Matches(this Pathy.ChainablePath path, params string[] globPatterns) { }
     }
 }

--- a/Pathy.Globbing/PathyGlobbing.cs
+++ b/Pathy.Globbing/PathyGlobbing.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
@@ -71,6 +72,97 @@ namespace Pathy
                 .Files
                 .Select(file => ChainablePath.From(path / file.Path))
                 .ToArray();
+        }
+
+        /// <summary>
+        /// Determines whether this path matches the provided glob pattern.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike <see cref="GlobFiles(ChainablePath, string)"/>, this does not touch the file system at all: the path
+        /// does not need to exist, and no directory is enumerated. The pattern is matched purely against the string
+        /// representation of <paramref name="path"/> (as returned by <see cref="ChainablePath.ToString"/>, which uses
+        /// the platform's directory separator), using
+        /// <see cref="global::Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.Match(Matcher, string, string)"/>.
+        /// That overload performs a pure in-memory string match (via <c>InMemoryDirectoryInfo</c>) and never
+        /// enumerates or reads from disk. For a rooted/absolute <paramref name="path"/> the pattern is matched
+        /// relative to its drive/volume root (so e.g. <c>src/**/*.cs</c> matches anywhere under that drive); for a
+        /// relative <paramref name="path"/> it is matched relative to the current working directory, same as
+        /// <see cref="GlobFiles(ChainablePath, string)"/> does.
+        /// </para>
+        /// <para>
+        /// This addresses the capability requested (but not delivered as a public API) in the closed issue #35: a way
+        /// to test whether a <see cref="ChainablePath"/> matches a wildcard/glob pattern without listing a directory.
+        /// It is named <c>Matches</c> here (plural-safe, with a multi-pattern overload) rather than reusing the
+        /// originally proposed <c>Match</c> name.
+        /// </para>
+        /// See also <seealso href="https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing"/>
+        /// </remarks>
+        /// <param name="path">The path to test against the glob pattern.</param>
+        /// <param name="globPattern">The glob pattern used to match the path, e.g. **/*.cs or **/bin/**</param>
+        public static bool Matches(this ChainablePath path, string globPattern)
+        {
+            return Matches(path, new[] { globPattern });
+        }
+
+        /// <summary>
+        /// Determines whether this path matches any of the provided glob patterns.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unlike <see cref="GlobFiles(ChainablePath, string[])"/>, this does not touch the file system at all: the
+        /// path does not need to exist, and no directory is enumerated. The pattern is matched purely against the
+        /// string representation of <paramref name="path"/> (as returned by <see cref="ChainablePath.ToString"/>,
+        /// which uses the platform's directory separator), using
+        /// <see cref="global::Microsoft.Extensions.FileSystemGlobbing.MatcherExtensions.Match(Matcher, string, string)"/>.
+        /// That overload performs a pure in-memory string match (via <c>InMemoryDirectoryInfo</c>) and never
+        /// enumerates or reads from disk. For a rooted/absolute <paramref name="path"/> the pattern is matched
+        /// relative to its drive/volume root (so e.g. <c>src/**/*.cs</c> matches anywhere under that drive); for a
+        /// relative <paramref name="path"/> it is matched relative to the current working directory, same as
+        /// <see cref="GlobFiles(ChainablePath, string[])"/> does.
+        /// </para>
+        /// <para>
+        /// This addresses the capability requested (but not delivered as a public API) in the closed issue #35: a way
+        /// to test whether a <see cref="ChainablePath"/> matches a wildcard/glob pattern without listing a directory.
+        /// It is named <c>Matches</c> here (plural-safe, with this multi-pattern overload) rather than reusing the
+        /// originally proposed <c>Match</c> name. This overload returns <see langword="true"/> if any of the
+        /// provided patterns matches.
+        /// </para>
+        /// See also <seealso href="https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing"/>
+        /// </remarks>
+        /// <param name="path">The path to test against the glob patterns.</param>
+        /// <param name="globPatterns">One or more glob patterns used to match the path, e.g. **/*.cs or **/bin/**</param>
+        /// <exception cref="ArgumentException">Thrown if no glob patterns are provided or if any pattern is null or empty.</exception>
+        public static bool Matches(this ChainablePath path, params string[] globPatterns)
+        {
+            if (globPatterns == null || globPatterns.Length == 0)
+            {
+                throw new ArgumentException("At least one glob pattern must be provided", nameof(globPatterns));
+            }
+
+            foreach (string pattern in globPatterns)
+            {
+                if (string.IsNullOrWhiteSpace(pattern))
+                {
+                    throw new ArgumentException("Glob patterns cannot be null or empty", nameof(globPatterns));
+                }
+            }
+
+            Matcher matcher = new(StringComparison.OrdinalIgnoreCase);
+            foreach (string pattern in globPatterns)
+            {
+                matcher.AddInclude(pattern);
+            }
+
+            string file = path.ToString();
+
+            // Match() never touches disk (Path.IsPathRooted/GetPathRoot are pure string operations), but the
+            // matcher still needs a root to compute file paths relative to. Anchoring to the drive/volume root for
+            // rooted paths ensures patterns like "src/**/*.cs" match wherever they occur on that drive, without
+            // requiring the path (or any directory) to actually exist.
+            string root = Path.IsPathRooted(file) ? Path.GetPathRoot(file) : Directory.GetCurrentDirectory();
+
+            return matcher.Match(root, file).HasMatches;
         }
     }
 }

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -597,6 +597,125 @@ public class ChainablePathSpecs
             .WithParameterName("globPatterns");
     }
 
+    // Issue #35 asked for a `Match(wildcard)` method and was closed without shipping a public API. `Matches`
+    // (below) is what actually delivers that capability - purely in-memory, without ever touching the file
+    // system or requiring the path to exist.
+    [Fact]
+    public void An_absolute_path_matches_a_pattern_that_corresponds_to_its_suffix()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "src" / "Pathy" / "ChainablePath.cs";
+
+        // Act & Assert
+        path.Matches("**/*.cs").Should().BeTrue();
+    }
+
+    [Fact]
+    public void An_absolute_path_does_not_match_an_unrelated_pattern()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "src" / "Pathy" / "ChainablePath.cs";
+
+        // Act & Assert
+        path.Matches("**/*.md").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_does_not_require_the_path_to_exist_on_disk()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / Guid.NewGuid().ToString("N") / "does-not-exist.cs";
+
+        // Act & Assert
+        path.Matches("**/*.cs").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_with_multiple_patterns_returns_true_if_any_pattern_matches()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "src" / "Pathy" / "ChainablePath.cs";
+
+        // Act & Assert
+        path.Matches("**/bin/**", "**/obj/**", "**/*.cs").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_with_multiple_patterns_returns_false_if_none_match()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "src" / "Pathy" / "ChainablePath.cs";
+
+        // Act & Assert
+        path.Matches("**/bin/**", "**/obj/**").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Matches_is_case_insensitive()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "src" / "Pathy" / "ChainablePath.cs";
+
+        // Act & Assert
+        path.Matches("**/*.CS").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Matches_with_single_pattern_throws_when_pattern_is_null()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "file.cs";
+
+        // Act & Assert
+        var act = () => path.Matches((string)null);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Glob patterns cannot be null or empty*")
+            .WithParameterName("globPatterns");
+    }
+
+    [Fact]
+    public void Matches_with_multiple_patterns_throws_when_no_patterns_provided()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "file.cs";
+
+        // Act & Assert
+        var act = () => path.Matches(new string[0]);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*At least one glob pattern must be provided*")
+            .WithParameterName("globPatterns");
+    }
+
+    [Fact]
+    public void Matches_with_multiple_patterns_throws_when_a_pattern_is_null()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "file.cs";
+
+        // Act & Assert
+        var act = () => path.Matches("**/*.cs", null, "**/*.doc");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Glob patterns cannot be null or empty*")
+            .WithParameterName("globPatterns");
+    }
+
+    [Fact]
+    public void Matches_with_multiple_patterns_throws_when_a_pattern_is_empty()
+    {
+        // Arrange
+        var path = ChainablePath.Temp / "file.cs";
+
+        // Act & Assert
+        var act = () => path.Matches("**/*.cs", "", "**/*.doc");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Glob patterns cannot be null or empty*")
+            .WithParameterName("globPatterns");
+    }
+
     [Fact]
     public void Can_convert_to_directory_info()
     {

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ ChainablePath[] files = (ChainablePath.Current / "Artifacts").GlobFiles("**/*.js
 ChainablePath[] files = (ChainablePath.Current / "Artifacts").GlobFiles("**/*.txt", "**/*.md", "**/*.json");
 ```
 
+The same package also provides `Matches`, which tests whether a path matches a glob pattern without touching
+the file system at all - the path doesn't need to exist and no directory is enumerated:
+
+```csharp
+changedFile.Matches("**/*.cs");                 // true for src/Pathy/ChainablePath.cs
+changedFile.Matches("**/bin/**", "**/obj/**");  // filter out build output
+var relevant = changedFiles.Where(x => x.Matches("src/**/*.cs")).ToArray();
+```
+
 ### File system operations
 
 Next to that, Pathy also provides a bunch of extension methods to operate on the file-system:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <h1 align="center">
+
+
   <br>
   <img src="./logo.png" style="width:300px" alt="Pathy"/>
   <br>


### PR DESCRIPTION
Fixes #142

## Summary

Adds `Matches(this ChainablePath path, string globPattern)` and `Matches(this ChainablePath path, params string[] globPatterns)` to `Pathy.Globbing` (`ChainablePathGlobbingExtensions`), next to the existing `GlobFiles`. This lets you test a path against one or more glob patterns without any file-system access — the path does not need to exist, and no directory is enumerated.

```csharp
changedFile.Matches("**/*.cs");                 // true for src/Pathy/ChainablePath.cs
changedFile.Matches("**/bin/**", "**/obj/**");  // filter out build output
var relevant = changedFiles.Where(x => x.Matches("src/**/*.cs")).ToArray();
```

## Note on base branch

CONTRIBUTING.md says PRs should target `develop`, but that branch does not currently exist in this repository, and all recent merged PRs target `main`. I opened this against `main` to match actual practice — happy to retarget if a `develop` branch gets created.

## No file-system access — how I verified it

I read the `Microsoft.Extensions.FileSystemGlobbing` source (`Matcher`, `MatcherExtensions`, `InMemoryDirectoryInfo`) rather than assuming behavior:

- `MatcherExtensions.Match(this Matcher, string root, string file)` executes the matcher against an `InMemoryDirectoryInfo`, which only does pure string operations (`Path.GetFullPath`, `Path.IsPathRooted`, etc.) on the given file path — it never enumerates a real directory or hits disk, even for a rooted/absolute path.
- The convenience single-arg `Match(string file)` overload just forwards to the two-arg one using `Directory.GetCurrentDirectory()` as root — but that only works correctly when `file` is actually under the current working directory (`MatcherContext` walks from the root down, so a file outside the root is silently never matched). Since `ChainablePath` values are typically absolute and unrelated to CWD, I did **not** use that overload directly.
- Instead, `Matches` computes the root itself: for a rooted path it uses `Path.GetPathRoot(file)` (the drive/volume root, e.g. `C:\`), guaranteeing the file is always "under" the root so patterns like `src/**/*.cs` match anywhere on that drive. For a relative path it falls back to `Directory.GetCurrentDirectory()`, matching `GlobFiles`'s existing behavior. `Path.GetPathRoot`/`Path.IsPathRooted` are pure string operations, so this remains fully I/O-free.
- Verified empirically with unit tests, including one that points at a path that doesn't exist on disk at all (`Matches_does_not_require_the_path_to_exist_on_disk`).

## Case sensitivity

Uses the same `new Matcher(StringComparison.OrdinalIgnoreCase)` construction as `GlobFiles`, for consistency. Covered by a `Matches_is_case_insensitive` test.

## Relationship to closed issue #35

#35 requested a `Match(wildcard)` method and was closed without a public API being approved/shipped. This PR delivers that capability, but:
- named `Matches` (plural-safe) instead of `Match`, with a companion `params string[]` overload that returns `true` if **any** pattern matches
- lives in `Pathy.Globbing` (not core `Pathy`), since it depends on `Microsoft.Extensions.FileSystemGlobbing`, same as `GlobFiles`

This is called out in the XML doc comments on both new members.

## Changes

- `Pathy.Globbing/PathyGlobbing.cs`: new `Matches` overloads, same argument validation as `GlobFiles` (throws `ArgumentException` for missing/null/empty patterns)
- `Pathy.Specs/ChainablePathSpecs.cs`: new specs — suffix match, unrelated pattern no-match, non-existent path, multi-pattern any-match / no-match, case-insensitivity, argument validation
- `Pathy.ApiVerificationTests/ApprovedApi/pathy.globbing.*.verified.txt`: updated approved public API surface via `AcceptApiChanges.ps1`
- `README.md`: documented `Matches` under the Globbing section

## Testing

- `dotnet test Pathy.Specs` — 119/119 passing
- `dotnet test Pathy.ApiVerificationTests` — 8/8 passing
- `dotnet build` (full solution) — 0 warnings, 0 errors

## Note on process

This issue is labeled `enhancement` only (no `api-approved` label), and CONTRIBUTING.md normally requires that label before opening a PR for an API change. The repo owner explicitly asked for this PR to be opened directly, so I'm proceeding, but flagging it here for visibility: **this implements an as-yet-unapproved API proposal.**