### PR TITLE
Add path output format options

### DIFF
--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net47.verified.txt
@@ -33,9 +33,13 @@ namespace Pathy
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
+        public string ToNativePath() { }
+        public string ToQuotedString() { }
         public override string ToString() { }
         public string ToString(string? format, System.IFormatProvider? formatProvider) { }
+        public string ToUnixPath() { }
         public System.Uri ToUri() { }
+        public string ToWindowsPath() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.net8.0.verified.txt
@@ -34,9 +34,13 @@ namespace Pathy
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
+        public string ToNativePath() { }
+        public string ToQuotedString() { }
         public override string ToString() { }
         public string ToString(string? format, System.IFormatProvider? formatProvider) { }
+        public string ToUnixPath() { }
         public System.Uri ToUri() { }
+        public string ToWindowsPath() { }
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.0.verified.txt
@@ -33,9 +33,13 @@ namespace Pathy
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
+        public string ToNativePath() { }
+        public string ToQuotedString() { }
         public override string ToString() { }
         public string ToString(string? format, System.IFormatProvider? formatProvider) { }
+        public string ToUnixPath() { }
         public System.Uri ToUri() { }
+        public string ToWindowsPath() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }

--- a/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
+++ b/Pathy.ApiVerificationTests/ApprovedApi/pathy.netstandard2.1.verified.txt
@@ -34,9 +34,13 @@ namespace Pathy
         public object ToAbsolute(Pathy.ChainablePath parentPath) { }
         public System.IO.DirectoryInfo ToDirectoryInfo() { }
         public System.IO.FileInfo ToFileInfo() { }
+        public string ToNativePath() { }
+        public string ToQuotedString() { }
         public override string ToString() { }
         public string ToString(string? format, System.IFormatProvider? formatProvider) { }
+        public string ToUnixPath() { }
         public System.Uri ToUri() { }
+        public string ToWindowsPath() { }
         public static Pathy.ChainablePath FindFirst(params Pathy.ChainablePath[] paths) { }
         public static Pathy.ChainablePath FindFirst(params string[] paths) { }
         public static Pathy.ChainablePath From(string path) { }

--- a/Pathy.Specs/ChainablePathSpecs.cs
+++ b/Pathy.Specs/ChainablePathSpecs.cs
@@ -78,13 +78,62 @@ public class ChainablePathSpecs
     public void Can_format_a_path_using_ToString_with_format_and_provider()
     {
         // Arrange
+        var path = ChainablePath.From(@"C:\some\my file.txt");
+
+        // Act
+        string result = path.ToString("U", CultureInfo.InvariantCulture);
+
+        // Assert
+        result.Should().Be("C:/some/my file.txt");
+    }
+
+    [Theory]
+    [InlineData("N", @"C:\some\my file.txt")]
+    [InlineData("U", "C:/some/my file.txt")]
+    [InlineData("W", @"C:\some\my file.txt")]
+    [InlineData("Q", "\"C:\\some\\my file.txt\"")]
+    public void Can_format_a_path_using_a_named_format(string format, string expected)
+    {
+        // Arrange
+        var path = ChainablePath.From(@"C:\some\my file.txt");
+
+        // Act
+        string result = path.ToString(format, CultureInfo.InvariantCulture);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Named_formatting_methods_match_their_format_specifiers()
+    {
+        // Arrange
+        var path = ChainablePath.From(@"C:\some\my file.txt");
+
+        // Act
+        string unixPath = path.ToUnixPath();
+        string windowsPath = path.ToWindowsPath();
+        string nativePath = path.ToNativePath();
+        string quotedPath = path.ToQuotedString();
+
+        // Assert
+        unixPath.Should().Be(path.ToString("U", null));
+        windowsPath.Should().Be(path.ToString("W", null));
+        nativePath.Should().Be(path.ToString("N", null));
+        quotedPath.Should().Be(path.ToString("Q", null));
+    }
+
+    [Fact]
+    public void An_unknown_format_is_not_supported()
+    {
+        // Arrange
         var path = ChainablePath.From(@"C:\some\file.txt");
 
         // Act
-        string result = path.ToString("whatever", CultureInfo.InvariantCulture);
+        var act = () => path.ToString("X", CultureInfo.InvariantCulture);
 
         // Assert
-        result.Should().Be(@"C:\some\file.txt");
+        act.Should().Throw<FormatException>();
     }
 
 #if NET6_0_OR_GREATER

--- a/Pathy/ChainablePath.cs
+++ b/Pathy/ChainablePath.cs
@@ -568,12 +568,52 @@ namespace Pathy
         /// Returns the string representation of the current <see cref="ChainablePath"/> instance.
         /// </summary>
         /// <remarks>
-        /// A <see cref="ChainablePath"/> has no format specifiers of its own, so <paramref name="format"/> and
-        /// <paramref name="formatProvider"/> are ignored and the underlying path is returned as-is.
+        /// The supported format specifiers are <c>N</c> for the native path, <c>U</c> for forward slashes,
+        /// <c>W</c> for backslashes, and <c>Q</c> for a native path quoted when it contains whitespace.
+        /// An empty or <see langword="null"/> format uses <c>N</c>.
         /// </remarks>
         public string ToString(string? format, IFormatProvider? formatProvider)
         {
+            return format switch
+            {
+                null or "" or "N" => path,
+                "U" => ToUnixPath(),
+                "W" => ToWindowsPath(),
+                "Q" => ToQuotedString(),
+                _ => throw new FormatException($"The format '{format}' is not supported.")
+            };
+        }
+
+        /// <summary>
+        /// Returns the path with forward slashes.
+        /// </summary>
+        public string ToUnixPath()
+        {
+            return path.Replace('\\', '/');
+        }
+
+        /// <summary>
+        /// Returns the path with backslashes.
+        /// </summary>
+        public string ToWindowsPath()
+        {
+            return path.Replace('/', '\\');
+        }
+
+        /// <summary>
+        /// Returns the path using the native separator for the current platform.
+        /// </summary>
+        public string ToNativePath()
+        {
             return path;
+        }
+
+        /// <summary>
+        /// Returns the native path surrounded by double quotes when it contains whitespace.
+        /// </summary>
+        public string ToQuotedString()
+        {
+            return path.Any(char.IsWhiteSpace) ? $"\"{path}\"" : path;
         }
 
 #if NET6_0_OR_GREATER
@@ -583,18 +623,20 @@ namespace Pathy
         /// for instance when the path is used inside an interpolated string.
         /// </summary>
         /// <remarks>
-        /// A <see cref="ChainablePath"/> has no format specifiers of its own, so <paramref name="format"/> and
-        /// <paramref name="provider"/> are ignored.
+        /// The supported format specifiers are <c>N</c> for the native path, <c>U</c> for forward slashes,
+        /// <c>W</c> for backslashes, and <c>Q</c> for a native path quoted when it contains whitespace.
         /// </remarks>
         public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
-            if (!path.AsSpan().TryCopyTo(destination))
+            string formattedPath = ToString(format.Length == 0 ? null : format.ToString(), provider);
+
+            if (!formattedPath.AsSpan().TryCopyTo(destination))
             {
                 charsWritten = 0;
                 return false;
             }
 
-            charsWritten = path.Length;
+            charsWritten = formattedPath.Length;
             return true;
         }
 #endif

--- a/README.md
+++ b/README.md
@@ -117,7 +117,21 @@ Console.WriteLine($"Deploying from {path}");   // no extra string allocation on 
 string message = string.Format("Path: {0}", path);
 ```
 
-`ChainablePath` has no format specifiers of its own, so any format string you pass (e.g. `path.ToString("X")`) is ignored and the plain path is returned.
+`ChainablePath` supports format specifiers for output that needs a specific separator:
+
+* `N` (or no format) uses the native separator for the current platform.
+* `U` uses forward slashes, which is useful for URLs, Docker and cross-platform output.
+* `W` uses backslashes.
+* `Q` uses the native separator and surrounds the path with double quotes when it contains whitespace.
+
+```csharp
+string unixPath = path.ToString("U");
+string quotedPath = path.ToQuotedString();
+string command = $"dotnet build {path:Q}";
+```
+
+The named methods `ToUnixPath()`, `ToWindowsPath()`, `ToNativePath()` and `ToQuotedString()` provide the same
+formats when interpolation is not needed. An unsupported format throws `FormatException`.
 
 ### Working with paths
 


### PR DESCRIPTION
## Why

Paths often need a separator or quoting style that differs from the current platform. Callers should not have to repeat string replacement and quoting logic when building URLs, Docker arguments, or shell commands.

## What changed

- Add `N`, `U`, `W`, and `Q` format specifiers to `ChainablePath`.
- Add named methods for native, Unix, Windows, and quoted output.
- Keep `ISpanFormattable` output consistent with the selected format.
- Document and test both API styles.

Closes #144